### PR TITLE
Update SearchParameter.php

### DIFF
--- a/config/asseco-json-query-builder.php
+++ b/config/asseco-json-query-builder.php
@@ -25,7 +25,7 @@ return [
     /**
      * Registered request parameters.
      */
-    'request_parameters'      => [
+    'request_parameters' => [
         SearchParameter::class,
         ReturnsParameter::class,
         OrderByParameter::class,
@@ -42,7 +42,7 @@ return [
      * Registered operators/callbacks. Operator order matters!
      * Callbacks having more const OPERATOR characters must come before those with less.
      */
-    'operators'              => [
+    'operators' => [
         NotBetween::class,
         LessThanOrEqual::class,
         GreaterThanOrEqual::class,
@@ -57,7 +57,7 @@ return [
      * Registered types. Generic type is the default one and should be used if
      * no special care for type value is needed.
      */
-    'types'                  => [
+    'types' => [
         GenericType::class,
         BooleanType::class,
     ],
@@ -76,7 +76,7 @@ return [
      * Refined options for a single model.
      * Use if you want to enforce rules on a specific model without affecting globally all models.
      */
-    'model_options'           => [
+    'model_options' => [
 
         /**
          * For real usage, use real models without quotes. This is only meant to show the available options.
@@ -95,13 +95,13 @@ return [
             /**
              * Disable search on specific columns. Searching on forbidden columns will throw an exception.
              */
-            'forbidden_columns'  => ['column', 'column2'],
+            'forbidden_columns' => ['column', 'column2'],
             /**
              * Array of columns to order by in 'column => direction' format.
              * 'order-by' from query string takes precedence before these values.
              */
-            'order_by'           => [
-                'id'         => 'asc',
+            'order_by' => [
+                'id' => 'asc',
                 'created_at' => 'desc',
             ],
             /**
@@ -109,11 +109,11 @@ return [
              * override these values. This acts as a 'SELECT /return only columns/' from.
              * By default, 'SELECT *' will be ran.
              */
-            'returns'           => ['column', 'column2'],
+            'returns' => ['column', 'column2'],
             /**
              * List of relations to load by default. These will be overridden if provided within query string.
              */
-            'relations'         => ['rel1', 'rel2'],
+            'relations' => ['rel1', 'rel2'],
 
             /**
              * TBD
@@ -121,7 +121,7 @@ return [
              * It is possible to map such columns so that the true ORM
              * property stays hidden.
              */
-            'column_mapping'     => [
+            'column_mapping' => [
                 'frontend_column' => 'backend_column',
             ],
         ],

--- a/src/RequestParameters/SearchParameter.php
+++ b/src/RequestParameters/SearchParameter.php
@@ -63,14 +63,13 @@ class SearchParameter extends AbstractParameter
 
             if ($this->queryInitiatedByTopLevelBool($key, $value)) {
                 if (is_array($value)) {
-                     // this must be treated together (with AND operator)
-                     // [0] => [
-                     //   [customFieldValues.date] => <>2024-01-01T00:00:00.000Z;2024-01-31T00:00:00.000Z
-                     //   [customFieldValues.custom_field_id] => =96e09c60-6e4f-4ab8-88f1-b21281008ad1
-                     // ]
+                    // this must be treated together (with AND operator)
+                    // [0] => [
+                    //   [customFieldValues.date] => <>2024-01-01T00:00:00.000Z;2024-01-31T00:00:00.000Z
+                    //   [customFieldValues.custom_field_id] => =96e09c60-6e4f-4ab8-88f1-b21281008ad1
+                    // ]
                     $this->makeSingleQueryArr($functionName, $builder, $value);
-                }
-                else {
+                } else {
                     $builder->{$functionName}(function ($queryBuilder) use ($value) {
                         // Recursion for inner keys which are &&/||
                         $this->makeQuery($queryBuilder, $value);
@@ -143,20 +142,20 @@ class SearchParameter extends AbstractParameter
     }
 
     /**
-     * @param string $functionName
-     * @param Builder $builder
-     * @param $values
+     * @param  string  $functionName
+     * @param  Builder  $builder
+     * @param  $values
      * @return void
+     *
      * @throws JsonQueryBuilderException
      */
     protected function makeSingleQueryArr(string $functionName, Builder $builder, $values): void
     {
         $builder->{$functionName}(function ($queryBuilder) use ($values, $functionName) {
-            foreach($values as $key => $value) {
+            foreach ($values as $key => $value) {
                 if (is_array($value)) {
                     $this->makeSingleQueryArr($functionName, $queryBuilder, $value);
-                }
-                else {
+                } else {
                     $this->applyArguments($queryBuilder, $this->operatorsConfig, $key, $value, 'AND');
                 }
             }

--- a/tests/Unit/JsonQueryTest.php
+++ b/tests/Unit/JsonQueryTest.php
@@ -214,7 +214,7 @@ class JsonQueryTest extends TestCase
     public function limits_and_offsets_results()
     {
         $input = [
-            'limit'  => 5,
+            'limit' => 5,
             'offset' => 10,
         ];
 
@@ -267,7 +267,7 @@ class JsonQueryTest extends TestCase
         $input = [
             'search' => [
                 '&&' => [
-                    '||'   => [
+                    '||' => [
                         'att1' => '=1',
                         'att2' => '=1',
                     ],
@@ -291,15 +291,15 @@ class JsonQueryTest extends TestCase
         $input = [
             'search' => [
                 '||' => [
-                    '&&'        => [
+                    '&&' => [
                         [
                             '||' => [
                                 [
-                                    'id'   => '=2||=3',
+                                    'id' => '=2||=3',
                                     'name' => '=foo',
                                 ],
                                 [
-                                    'id'   => '=1',
+                                    'id' => '=1',
                                     'name' => '=foo%&&=%bar',
                                 ],
                             ],
@@ -308,7 +308,7 @@ class JsonQueryTest extends TestCase
                             'we' => '=cool',
                         ],
                     ],
-                    'love'      => '<3',
+                    'love' => '<3',
                     'recursion' => '=rrr',
                 ],
             ],


### PR DESCRIPTION
fix for SearchableItem with multiple items in query, which has to be inspected together, with AND operator

Example:
[0] => [
  [customFieldValues.date] => <>2024-01-01T00:00:00.000Z;2024-01-31T00:00:00.000Z
  [customFieldValues.custom_field_id] => =96e09c60-6e4f-4ab8-88f1-b21281008ad1
]