### PR TITLE
Extend for cf custom field search parser

### DIFF
--- a/config/asseco-json-query-builder.php
+++ b/config/asseco-json-query-builder.php
@@ -25,7 +25,7 @@ return [
     /**
      * Registered request parameters.
      */
-    'request_parameters'      => [
+    'request_parameters' => [
         SearchParameter::class,
         ReturnsParameter::class,
         OrderByParameter::class,
@@ -42,7 +42,7 @@ return [
      * Registered operators/callbacks. Operator order matters!
      * Callbacks having more const OPERATOR characters must come before those with less.
      */
-    'operators'              => [
+    'operators' => [
         NotBetween::class,
         LessThanOrEqual::class,
         GreaterThanOrEqual::class,
@@ -57,7 +57,7 @@ return [
      * Registered types. Generic type is the default one and should be used if
      * no special care for type value is needed.
      */
-    'types'                  => [
+    'types' => [
         GenericType::class,
         BooleanType::class,
     ],
@@ -76,7 +76,7 @@ return [
      * Refined options for a single model.
      * Use if you want to enforce rules on a specific model without affecting globally all models.
      */
-    'model_options'           => [
+    'model_options' => [
 
         /**
          * For real usage, use real models without quotes. This is only meant to show the available options.
@@ -95,13 +95,13 @@ return [
             /**
              * Disable search on specific columns. Searching on forbidden columns will throw an exception.
              */
-            'forbidden_columns'  => ['column', 'column2'],
+            'forbidden_columns' => ['column', 'column2'],
             /**
              * Array of columns to order by in 'column => direction' format.
              * 'order-by' from query string takes precedence before these values.
              */
-            'order_by'           => [
-                'id'         => 'asc',
+            'order_by' => [
+                'id' => 'asc',
                 'created_at' => 'desc',
             ],
             /**
@@ -109,11 +109,11 @@ return [
              * override these values. This acts as a 'SELECT /return only columns/' from.
              * By default, 'SELECT *' will be ran.
              */
-            'returns'           => ['column', 'column2'],
+            'returns' => ['column', 'column2'],
             /**
              * List of relations to load by default. These will be overridden if provided within query string.
              */
-            'relations'         => ['rel1', 'rel2'],
+            'relations' => ['rel1', 'rel2'],
 
             /**
              * TBD
@@ -121,7 +121,7 @@ return [
              * It is possible to map such columns so that the true ORM
              * property stays hidden.
              */
-            'column_mapping'     => [
+            'column_mapping' => [
                 'frontend_column' => 'backend_column',
             ],
         ],

--- a/src/CategorizedValues.php
+++ b/src/CategorizedValues.php
@@ -17,7 +17,7 @@ class CategorizedValues
     const IS_NULL = 'null';
     const IS_NOT_NULL = '!null';
 
-    protected SearchParser $searchParser;
+    protected SearchParserInterface $searchParser;
 
     public array $and = [];
     public array $andLike = [];
@@ -31,11 +31,11 @@ class CategorizedValues
     /**
      * CategorizedValues constructor.
      *
-     * @param  SearchParser  $searchParser
+     * @param  SearchParserInterface  $searchParser
      *
      * @throws Exceptions\JsonQueryBuilderException
      */
-    public function __construct(SearchParser $searchParser)
+    public function __construct(SearchParserInterface $searchParser)
     {
         $this->searchParser = $searchParser;
 

--- a/src/CustomFieldSearchParser.php
+++ b/src/CustomFieldSearchParser.php
@@ -10,7 +10,7 @@ use Asseco\JsonQueryBuilder\Exceptions\JsonQueryBuilderException;
 use Asseco\JsonQueryBuilder\Traits\CleansValues;
 use Illuminate\Support\Facades\Config;
 
-class SearchParser implements SearchParserInterface
+class CustomFieldSearchParser implements SearchParserInterface
 {
     use CleansValues;
 
@@ -20,32 +20,39 @@ class SearchParser implements SearchParserInterface
     const VALUE_SEPARATOR = ';';
 
     public string $column;
+    private string $argument;
     public array  $values;
     public string $type;
     public string $operator;
 
-    private string      $argument;
+    public string $cf_field_identificator = 'custom_field_id';
+    public string $cf_field_value = '';
+
     private ModelConfig $modelConfig;
 
     /**
-     * Search constructor.
-     *
-     * @param  ModelConfig  $modelConfig
-     * @param  OperatorsConfig  $operatorsConfig
-     * @param  string  $column
-     * @param  string  $argument
-     *
+     * @param ModelConfig $modelConfig
+     * @param OperatorsConfig $operatorsConfig
+     * @param array $arguments
      * @throws JsonQueryBuilderException
      */
-    public function __construct(ModelConfig $modelConfig, OperatorsConfig $operatorsConfig, string $column, string $argument)
+    public function __construct(ModelConfig $modelConfig, OperatorsConfig $operatorsConfig, array $arguments)
     {
         $this->modelConfig = $modelConfig;
-        $this->column = $column;
-        $this->argument = $argument;
+
+        foreach($arguments as $col => $val) {
+            if (str_contains($col, $this->cf_field_identificator)) {
+                $this->cf_field_value = $val;
+            }
+            else {
+                $this->column = $col;
+                $this->argument = $val;
+            }
+        }
 
         $this->checkForForbiddenColumns();
 
-        $this->operator = $this->parseOperator($operatorsConfig->getOperators(), $argument);
+        $this->operator = $this->parseOperator($operatorsConfig->getOperators(), $this->argument);
         $arguments = str_replace($this->operator, '', $this->argument);
         $this->values = $this->splitValues($arguments);
         $this->type = $this->getColumnType();

--- a/src/CustomFieldSearchParser.php
+++ b/src/CustomFieldSearchParser.php
@@ -31,20 +31,20 @@ class CustomFieldSearchParser implements SearchParserInterface
     private ModelConfig $modelConfig;
 
     /**
-     * @param ModelConfig $modelConfig
-     * @param OperatorsConfig $operatorsConfig
-     * @param array $arguments
+     * @param  ModelConfig  $modelConfig
+     * @param  OperatorsConfig  $operatorsConfig
+     * @param  array  $arguments
+     *
      * @throws JsonQueryBuilderException
      */
     public function __construct(ModelConfig $modelConfig, OperatorsConfig $operatorsConfig, array $arguments)
     {
         $this->modelConfig = $modelConfig;
 
-        foreach($arguments as $col => $val) {
+        foreach ($arguments as $col => $val) {
             if (str_contains($col, $this->cf_field_identificator)) {
                 $this->cf_field_value = $val;
-            }
-            else {
+            } else {
                 $this->column = $col;
                 $this->argument = $val;
             }

--- a/src/RequestParameters/SearchParameter.php
+++ b/src/RequestParameters/SearchParameter.php
@@ -9,6 +9,8 @@ use Asseco\JsonQueryBuilder\Exceptions\JsonQueryBuilderException;
 use Asseco\JsonQueryBuilder\JsonQuery;
 use Asseco\JsonQueryBuilder\SearchCallbacks\AbstractCallback;
 use Asseco\JsonQueryBuilder\SearchParser;
+use Asseco\JsonQueryBuilder\CustomFieldSearchParser;
+use Asseco\JsonQueryBuilder\SearchParserInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 
@@ -16,6 +18,8 @@ class SearchParameter extends AbstractParameter
 {
     const OR = '||';
     const AND = '&&';
+
+    const AND_INCLUSIVE_CF = '&&_INC_CF';
 
     const LARAVEL_WHERE = 'where';
     const LARAVEL_OR_WHERE = 'orWhere';
@@ -61,7 +65,15 @@ class SearchParameter extends AbstractParameter
 
             $functionName = $this->getQueryFunctionName($boolOperator);
 
-            if ($this->queryInitiatedByTopLevelBool($key, $value)) {
+            if ($this->isTopLevelInclusiveCFOperator( $key)) {
+                // Custom fields custom search logic ..... both columns has to be in the same where clause (custom_field_id & search column)
+                $builder->{$functionName}(function ($queryBuilder) use ($key, $value) {
+                    $searchModel = new CustomFieldSearchParser($this->modelConfig, $this->operatorsConfig, $value);
+                    $this->appendSingle($queryBuilder, $this->operatorsConfig, $searchModel);
+                });
+                continue;
+            }
+            else if ($this->queryInitiatedByTopLevelBool($key, $value)) {
                 $builder->{$functionName}(function ($queryBuilder) use ($value) {
                     // Recursion for inner keys which are &&/||
                     $this->makeQuery($queryBuilder, $value);
@@ -87,6 +99,11 @@ class SearchParameter extends AbstractParameter
         return in_array($key, [self::OR, self::AND], true);
     }
 
+    protected function isTopLevelInclusiveCFOperator($key): bool
+    {
+        return in_array($key, [self::AND_INCLUSIVE_CF], true);
+    }
+
     /**
      * @param  string  $boolOperator
      * @return string
@@ -95,7 +112,7 @@ class SearchParameter extends AbstractParameter
      */
     protected function getQueryFunctionName(string $boolOperator): string
     {
-        if ($boolOperator === self::AND) {
+        if ($boolOperator === self::AND || $boolOperator === self::AND_INCLUSIVE_CF) {
             return self::LARAVEL_WHERE;
         } elseif ($boolOperator === self::OR) {
             return self::LARAVEL_OR_WHERE;
@@ -186,7 +203,7 @@ class SearchParameter extends AbstractParameter
      *
      * @throws JsonQueryBuilderException
      */
-    protected function appendSingle(Builder $builder, OperatorsConfig $operatorsConfig, SearchParser $searchParser): void
+    protected function appendSingle(Builder $builder, OperatorsConfig $operatorsConfig, SearchParserInterface $searchParser): void
     {
         $callbackClassName = $operatorsConfig->getCallbackClassFromOperator($searchParser->operator);
 

--- a/src/RequestParameters/SearchParameter.php
+++ b/src/RequestParameters/SearchParameter.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Asseco\JsonQueryBuilder\RequestParameters;
 
 use Asseco\JsonQueryBuilder\Config\OperatorsConfig;
+use Asseco\JsonQueryBuilder\CustomFieldSearchParser;
 use Asseco\JsonQueryBuilder\Exceptions\JsonQueryBuilderException;
 use Asseco\JsonQueryBuilder\JsonQuery;
 use Asseco\JsonQueryBuilder\SearchCallbacks\AbstractCallback;
 use Asseco\JsonQueryBuilder\SearchParser;
-use Asseco\JsonQueryBuilder\CustomFieldSearchParser;
 use Asseco\JsonQueryBuilder\SearchParserInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
@@ -65,15 +65,14 @@ class SearchParameter extends AbstractParameter
 
             $functionName = $this->getQueryFunctionName($boolOperator);
 
-            if ($this->isTopLevelInclusiveCFOperator( $key)) {
+            if ($this->isTopLevelInclusiveCFOperator($key)) {
                 // Custom fields custom search logic ..... both columns has to be in the same where clause (custom_field_id & search column)
-                $builder->{$functionName}(function ($queryBuilder) use ($key, $value) {
+                $builder->{$functionName}(function ($queryBuilder) use ($value) {
                     $searchModel = new CustomFieldSearchParser($this->modelConfig, $this->operatorsConfig, $value);
                     $this->appendSingle($queryBuilder, $this->operatorsConfig, $searchModel);
                 });
                 continue;
-            }
-            else if ($this->queryInitiatedByTopLevelBool($key, $value)) {
+            } elseif ($this->queryInitiatedByTopLevelBool($key, $value)) {
                 $builder->{$functionName}(function ($queryBuilder) use ($value) {
                     // Recursion for inner keys which are &&/||
                     $this->makeQuery($queryBuilder, $value);

--- a/src/SearchCallbacks/AbstractCallback.php
+++ b/src/SearchCallbacks/AbstractCallback.php
@@ -7,7 +7,6 @@ namespace Asseco\JsonQueryBuilder\SearchCallbacks;
 use Asseco\JsonQueryBuilder\CategorizedValues;
 use Asseco\JsonQueryBuilder\CustomFieldSearchParser;
 use Asseco\JsonQueryBuilder\Exceptions\JsonQueryBuilderException;
-use Asseco\JsonQueryBuilder\SearchParser;
 use Asseco\JsonQueryBuilder\SearchParserInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
@@ -49,11 +48,10 @@ abstract class AbstractCallback
                     return;
                 }
                 $this->appendRelations($builder, $this->searchParser->column, $this->categorizedValues);
-
             },
             function (Builder $builder) {
                 $this->execute($builder, $this->searchParser->column, $this->categorizedValues);
-                $this->checkExecuteForCustomfieldsParameter( $builder );
+                $this->checkExecuteForCustomfieldsParameter($builder);
             }
         );
     }
@@ -91,7 +89,7 @@ abstract class AbstractCallback
             }
 
             $this->execute($builder, $relatedColumns, $values);
-            $this->checkExecuteForCustomfieldsParameter( $builder );
+            $this->checkExecuteForCustomfieldsParameter($builder);
         });
     }
 
@@ -170,7 +168,8 @@ abstract class AbstractCallback
         return 'LIKE';
     }
 
-    protected function checkExecuteForCustomfieldsParameter( $builder ) {
+    protected function checkExecuteForCustomfieldsParameter($builder)
+    {
         if ($this->searchParser instanceof CustomFieldSearchParser) {
             $builder->where($this->searchParser->cf_field_identificator, '=', $this->searchParser->cf_field_value);
         }

--- a/src/SearchCallbacks/AbstractCallback.php
+++ b/src/SearchCallbacks/AbstractCallback.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Asseco\JsonQueryBuilder\SearchCallbacks;
 
 use Asseco\JsonQueryBuilder\CategorizedValues;
+use Asseco\JsonQueryBuilder\CustomFieldSearchParser;
 use Asseco\JsonQueryBuilder\Exceptions\JsonQueryBuilderException;
 use Asseco\JsonQueryBuilder\SearchParser;
+use Asseco\JsonQueryBuilder\SearchParserInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -15,7 +17,7 @@ use PDO;
 abstract class AbstractCallback
 {
     protected Builder $builder;
-    protected SearchParser $searchParser;
+    protected SearchParserInterface $searchParser;
     protected CategorizedValues $categorizedValues;
 
     protected const DATE_FIELDS = [
@@ -26,11 +28,11 @@ abstract class AbstractCallback
      * AbstractCallback constructor.
      *
      * @param  Builder  $builder
-     * @param  SearchParser  $searchParser
+     * @param  SearchParserInterface  $searchParser
      *
      * @throws JsonQueryBuilderException
      */
-    public function __construct(Builder $builder, SearchParser $searchParser)
+    public function __construct(Builder $builder, SearchParserInterface $searchParser)
     {
         $this->builder = $builder;
         $this->searchParser = $searchParser;
@@ -47,9 +49,11 @@ abstract class AbstractCallback
                     return;
                 }
                 $this->appendRelations($builder, $this->searchParser->column, $this->categorizedValues);
+
             },
             function (Builder $builder) {
                 $this->execute($builder, $this->searchParser->column, $this->categorizedValues);
+                $this->checkExecuteForCustomfieldsParameter( $builder );
             }
         );
     }
@@ -87,6 +91,7 @@ abstract class AbstractCallback
             }
 
             $this->execute($builder, $relatedColumns, $values);
+            $this->checkExecuteForCustomfieldsParameter( $builder );
         });
     }
 
@@ -163,5 +168,11 @@ abstract class AbstractCallback
         }
 
         return 'LIKE';
+    }
+
+    protected function checkExecuteForCustomfieldsParameter( $builder ) {
+        if ($this->searchParser instanceof CustomFieldSearchParser) {
+            $builder->where($this->searchParser->cf_field_identificator, '=', $this->searchParser->cf_field_value);
+        }
     }
 }

--- a/src/SearchParserInterface.php
+++ b/src/SearchParserInterface.php
@@ -1,9 +1,9 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Asseco\JsonQueryBuilder;
 
 interface SearchParserInterface
 {
-
 }

--- a/src/SearchParserInterface.php
+++ b/src/SearchParserInterface.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Asseco\JsonQueryBuilder;
+
+interface SearchParserInterface
+{
+
+}

--- a/tests/Unit/JsonQueryTest.php
+++ b/tests/Unit/JsonQueryTest.php
@@ -214,7 +214,7 @@ class JsonQueryTest extends TestCase
     public function limits_and_offsets_results()
     {
         $input = [
-            'limit'  => 5,
+            'limit' => 5,
             'offset' => 10,
         ];
 
@@ -267,7 +267,7 @@ class JsonQueryTest extends TestCase
         $input = [
             'search' => [
                 '&&' => [
-                    '||'   => [
+                    '||' => [
                         'att1' => '=1',
                         'att2' => '=1',
                     ],
@@ -291,15 +291,15 @@ class JsonQueryTest extends TestCase
         $input = [
             'search' => [
                 '||' => [
-                    '&&'        => [
+                    '&&' => [
                         [
                             '||' => [
                                 [
-                                    'id'   => '=2||=3',
+                                    'id' => '=2||=3',
                                     'name' => '=foo',
                                 ],
                                 [
-                                    'id'   => '=1',
+                                    'id' => '=1',
                                     'name' => '=foo%&&=%bar',
                                 ],
                             ],
@@ -308,7 +308,7 @@ class JsonQueryTest extends TestCase
                             'we' => '=cool',
                         ],
                     ],
-                    'love'      => '<3',
+                    'love' => '<3',
                     'recursion' => '=rrr',
                 ],
             ],


### PR DESCRIPTION
intruduce CustomFieldSearchParser which will handle correct search for CustomFieldSearchable

/*
...

$searchable = new SearchableItem($customField->label, [
  '&&_INC_CF' => [
    "customFieldValues.{$valueColumn}" => Placeholders::SEARCH,
    "customFieldValues.custom_field_id" => $customField->id,
   ]
], $type);
$searchable->values($values);

...
*/