### PR TITLE
Enable raw arguments in query

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ be used together with ``limit`` parameter.
 - `count` - will return record count.
 - `soft_deleted` - will include soft deleted models in search results.
 - `doesnt_have_relations` - will only return entries that don't have any of the specified relations.
+- `use_raw_arguments` - will use raw SQL for group_by (groupByRaw) & returns (selectRaw)
 
 ### Search
 
@@ -115,6 +116,23 @@ case-insensitive search.
 
 Will perform a ``SELECT * FROM some_table WHERE first_name LIKE 'foo' AND
 last_name NOT LIKE 'bar'``.
+
+Example with raw query
+{
+    "search": {
+        ...
+    },
+    "group_by": ["year", "month"],
+    "order_by": ["year", "month"],
+    "returns": ["DATE_PART('Year', created_at) AS year", "DATE_PART('Month', created_at) AS month", "COUNT(*) AS total"],
+    "use_raw_arguments": 1
+}
+
+Will perform:  
+``select DATE_PART(\'Year\', created_at) AS year, DATE_PART(\'Month\', created_at) AS month, COUNT(*) AS total   
+from ....   
+group by year, month order by "year" asc, "month" asc``
+
 
 #### Micro operators
 

--- a/src/JsonQuery.php
+++ b/src/JsonQuery.php
@@ -65,13 +65,18 @@ class JsonQuery
      */
     protected function appendParameterQueries(): void
     {
+        // enable raw arguments
+        // will use raw method rather then basic ones, in group_by and returns
+        // $builder->selectRaw, $builder->groupByRaw
+        $rawArguments = boolval($this->input['use_raw_arguments'] ?? false) ?? false;
+
         foreach ($this->registeredParameters as $requestParameter) {
             if (!$this->parameterExists($requestParameter)) {
                 // TODO: append config query?
                 continue;
             }
 
-            $this->instantiateRequestParameter($requestParameter)
+            $this->instantiateRequestParameter($requestParameter, $rawArguments)
                 ->run();
         }
     }
@@ -97,12 +102,12 @@ class JsonQuery
     }
 
     /**
-     * @param  $requestParameter
+     * @param string $requestParameter
+     * @param bool|null $rawArguments
      * @return AbstractParameter
-     *
      * @throws JsonQueryBuilderException
      */
-    protected function instantiateRequestParameter(string $requestParameter): AbstractParameter
+    protected function instantiateRequestParameter(string $requestParameter, ?bool $rawArguments = false): AbstractParameter
     {
         if (!is_subclass_of($requestParameter, AbstractParameter::class)) {
             throw new JsonQueryBuilderException("$requestParameter must extend " . AbstractParameter::class);
@@ -110,7 +115,7 @@ class JsonQuery
 
         $input = $this->wrapInput($requestParameter::getParameterName());
 
-        return new $requestParameter($input, $this->builder, $this->modelConfig);
+        return new $requestParameter($input, $this->builder, $this->modelConfig, $rawArguments);
     }
 
     /**

--- a/src/JsonQuery.php
+++ b/src/JsonQuery.php
@@ -102,9 +102,10 @@ class JsonQuery
     }
 
     /**
-     * @param string $requestParameter
-     * @param bool|null $rawArguments
+     * @param  string  $requestParameter
+     * @param  bool|null  $rawArguments
      * @return AbstractParameter
+     *
      * @throws JsonQueryBuilderException
      */
     protected function instantiateRequestParameter(string $requestParameter, ?bool $rawArguments = false): AbstractParameter

--- a/src/RequestParameters/AbstractParameter.php
+++ b/src/RequestParameters/AbstractParameter.php
@@ -16,11 +16,12 @@ abstract class AbstractParameter
     protected bool     $rawArguments;
 
     /**
-     * AbstractParameter constructor
-     * @param array $arguments
-     * @param Builder $builder
-     * @param ModelConfig $modelConfig
-     * @param bool|null $rawArguents
+     * AbstractParameter constructor.
+     *
+     * @param  array  $arguments
+     * @param  Builder  $builder
+     * @param  ModelConfig  $modelConfig
+     * @param  bool|null  $rawArguents
      */
     public function __construct(array $arguments, Builder $builder, ModelConfig $modelConfig, ?bool $rawArguments = false)
     {

--- a/src/RequestParameters/AbstractParameter.php
+++ b/src/RequestParameters/AbstractParameter.php
@@ -13,19 +13,21 @@ abstract class AbstractParameter
     public Builder     $builder;
     public ModelConfig $modelConfig;
     protected array    $arguments;
+    protected bool     $rawArguments;
 
     /**
-     * AbstractParameter constructor.
-     *
-     * @param  array  $arguments
-     * @param  Builder  $builder
-     * @param  ModelConfig  $modelConfig
+     * AbstractParameter constructor
+     * @param array $arguments
+     * @param Builder $builder
+     * @param ModelConfig $modelConfig
+     * @param bool|null $rawArguents
      */
-    public function __construct(array $arguments, Builder $builder, ModelConfig $modelConfig)
+    public function __construct(array $arguments, Builder $builder, ModelConfig $modelConfig, ?bool $rawArguments = false)
     {
         $this->arguments = $arguments;
         $this->builder = $builder;
         $this->modelConfig = $modelConfig;
+        $this->rawArguments = $rawArguments;
     }
 
     /**

--- a/src/RequestParameters/GroupByParameter.php
+++ b/src/RequestParameters/GroupByParameter.php
@@ -15,9 +15,8 @@ class GroupByParameter extends AbstractParameter
     {
         if (!$this->rawArguments) {
             $this->builder->groupBy($this->arguments);
-        }
-        else {
-            foreach($this->arguments as $arg) {
+        } else {
+            foreach ($this->arguments as $arg) {
                 $this->builder->groupByRaw($arg);
             }
         }

--- a/src/RequestParameters/GroupByParameter.php
+++ b/src/RequestParameters/GroupByParameter.php
@@ -13,6 +13,13 @@ class GroupByParameter extends AbstractParameter
 
     protected function appendQuery(): void
     {
-        $this->builder->groupBy($this->arguments);
+        if (!$this->rawArguments) {
+            $this->builder->groupBy($this->arguments);
+        }
+        else {
+            foreach($this->arguments as $arg) {
+                $this->builder->groupByRaw($arg);
+            }
+        }
     }
 }

--- a/src/RequestParameters/ReturnsParameter.php
+++ b/src/RequestParameters/ReturnsParameter.php
@@ -15,10 +15,9 @@ class ReturnsParameter extends AbstractParameter
     {
         if (!$this->rawArguments) {
             $this->builder->addSelect($this->arguments);
-        }
-        else {
-            foreach($this->arguments as $arg) {
-                $this->builder->selectRaw( $arg );
+        } else {
+            foreach ($this->arguments as $arg) {
+                $this->builder->selectRaw($arg);
             }
         }
     }

--- a/src/RequestParameters/ReturnsParameter.php
+++ b/src/RequestParameters/ReturnsParameter.php
@@ -13,6 +13,13 @@ class ReturnsParameter extends AbstractParameter
 
     protected function appendQuery(): void
     {
-        $this->builder->addSelect($this->arguments);
+        if (!$this->rawArguments) {
+            $this->builder->addSelect($this->arguments);
+        }
+        else {
+            foreach($this->arguments as $arg) {
+                $this->builder->selectRaw( $arg );
+            }
+        }
     }
 }


### PR DESCRIPTION
Option to handle request parameters as raw arguments.

For example:
api/search/{model}

{
     "search": {
        "remote_relations.remote_model_type": "=contact",
        "remote_relations.remote_model_id": "=...."
    },
    "group_by": ["year", "month"],
    "order_by": ["year", "month"],
    "returns": ["DATE_PART('Year', created_at) AS year", "DATE_PART('Month', created_at) AS month", "COUNT(*) AS total"],
    "use_raw_arguments": 1
}