### PR TITLE
Less or more operator: do not use whereDate if type is datetime

### DIFF
--- a/src/SearchCallbacks/AbstractCallback.php
+++ b/src/SearchCallbacks/AbstractCallback.php
@@ -20,7 +20,7 @@ abstract class AbstractCallback
     protected CategorizedValues $categorizedValues;
 
     protected const DATE_FIELDS = [
-        'date', 'datetime',
+        'date',
     ];
 
     /**


### PR DESCRIPTION
If the following comes to the backend:
`>2024-02-10T23:00:00.000Z&&<2024-02-17T23:00:00.000Z`
date times will be cast and it will result in this:
`>2024-02-10&&<2024-02-17`

That means that records that have date time after 23 hours on February 10th will not be returned as well as records that have date time anytime on February 17th.